### PR TITLE
Add editable service centers

### DIFF
--- a/app/admin-panel/services/create/page.tsx
+++ b/app/admin-panel/services/create/page.tsx
@@ -24,6 +24,7 @@ export default function CreateServicePage() {
   const [department, setDepartment] = useState("")
   const [cost, setCost] = useState("")
   const [applyUrl, setApplyUrl] = useState("")
+  const [centers, setCenters] = useState<string[]>(["", "", ""])
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const router = useRouter()
@@ -44,6 +45,7 @@ export default function CreateServicePage() {
         procedure,
         department,
         cost,
+        centers: centers.filter((c) => c.trim().length > 0),
         apply_url: applyUrl || null,
         views: 0,
         created_at: new Date().toISOString(),
@@ -129,6 +131,36 @@ export default function CreateServicePage() {
                       type="url"
                       value={applyUrl}
                       onChange={(e) => setApplyUrl(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="center1">Центр 1</Label>
+                    <Input
+                      id="center1"
+                      value={centers[0]}
+                      onChange={(e) =>
+                        setCenters([e.target.value, centers[1], centers[2]])
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="center2">Центр 2 (необязательно)</Label>
+                    <Input
+                      id="center2"
+                      value={centers[1]}
+                      onChange={(e) =>
+                        setCenters([centers[0], e.target.value, centers[2]])
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="center3">Центр 3 (необязательно)</Label>
+                    <Input
+                      id="center3"
+                      value={centers[2]}
+                      onChange={(e) =>
+                        setCenters([centers[0], centers[1], e.target.value])
+                      }
                     />
                   </div>
                 </div>

--- a/app/admin-panel/services/edit/[id]/page.tsx
+++ b/app/admin-panel/services/edit/[id]/page.tsx
@@ -28,6 +28,7 @@ export default function EditServicePage({ params }: any) {
   const [department, setDepartment] = useState("")
   const [cost, setCost] = useState("")
   const [applyUrl, setApplyUrl] = useState("")
+  const [centers, setCenters] = useState<string[]>(["", "", ""])
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -58,6 +59,11 @@ export default function EditServicePage({ params }: any) {
         setDepartment(data.department || "")
         setCost(data.cost || "")
         setApplyUrl(data.apply_url || "")
+        setCenters(
+          data.centers && Array.isArray(data.centers)
+            ? [data.centers[0] || "", data.centers[1] || "", data.centers[2] || ""]
+            : ["", "", ""]
+        )
 
       } catch (error: any) {
         console.error(
@@ -92,6 +98,7 @@ export default function EditServicePage({ params }: any) {
           procedure,
         department,
         cost,
+        centers: centers.filter((c) => c.trim().length > 0),
         apply_url: applyUrl || null,
         updated_at: new Date().toISOString(),
       })
@@ -206,6 +213,36 @@ export default function EditServicePage({ params }: any) {
                       type="url"
                       value={applyUrl}
                       onChange={(e) => setApplyUrl(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="center1">Центр 1</Label>
+                    <Input
+                      id="center1"
+                      value={centers[0]}
+                      onChange={(e) =>
+                        setCenters([e.target.value, centers[1], centers[2]])
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="center2">Центр 2 (необязательно)</Label>
+                    <Input
+                      id="center2"
+                      value={centers[1]}
+                      onChange={(e) =>
+                        setCenters([centers[0], e.target.value, centers[2]])
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="center3">Центр 3 (необязательно)</Label>
+                    <Input
+                      id="center3"
+                      value={centers[2]}
+                      onChange={(e) =>
+                        setCenters([centers[0], centers[1], e.target.value])
+                      }
                     />
                   </div>
                 </div>

--- a/app/services/[id]/page.tsx
+++ b/app/services/[id]/page.tsx
@@ -116,19 +116,19 @@ export default async function ServicePage({ params }: { params: { id: string } }
                 </Link>
               </Button>
 
-              <div className="pt-4">
-                <h4 className="font-medium mb-2">Центры оказания услуги</h4>
-                <ul className="space-y-2 text-sm">
-                  <li className="flex items-start gap-2">
-                    <FileCheck className="h-4 w-4 text-muted-foreground mt-0.5" />
-                    <span>Адрес больки лс</span>
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <FileCheck className="h-4 w-4 text-muted-foreground mt-0.5" />
-                    <span>Адрес больки сш</span>
-                  </li>
-                </ul>
-              </div>
+              {service.centers.length > 0 && (
+                <div className="pt-4">
+                  <h4 className="font-medium mb-2">Центры оказания услуги</h4>
+                  <ul className="space-y-2 text-sm">
+                    {service.centers.map((center, idx) => (
+                      <li key={idx} className="flex items-start gap-2">
+                        <FileCheck className="h-4 w-4 text-muted-foreground mt-0.5" />
+                        <span>{center}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -15,6 +15,7 @@ export async function getPopularServices(): Promise<Service[]> {
     return data.map((item: any) => ({
       ...item,
       applyUrl: item.apply_url ?? null,
+      centers: item.centers ?? [],
     })) as Service[]
   } catch (error) {
     console.error("Error fetching popular services:", error)
@@ -38,6 +39,7 @@ export async function getServiceById(id: string): Promise<Service | null> {
     return {
       ...data,
       applyUrl: data.apply_url ?? null,
+      centers: data.centers ?? [],
     } as Service
   } catch (error) {
     console.error(`Error fetching service with id ${id}:`, error)
@@ -59,6 +61,7 @@ export async function getAllServices(): Promise<Service[]> {
     return data.map((item: any) => ({
       ...item,
       applyUrl: item.apply_url ?? null,
+      centers: item.centers ?? [],
     })) as Service[]
   } catch (error) {
     console.error("Error fetching all services:", error)
@@ -79,6 +82,7 @@ function getMockPopularServices(): Service[] {
       department: "Департамент внутренних дел",
       cost: "1000",
       applyUrl: "https://example.com/apply-passport",
+      centers: [],
       views: 1500,
       createdAt: new Date("2023-01-15"),
       updatedAt: new Date("2023-06-20"),
@@ -93,6 +97,7 @@ function getMockPopularServices(): Service[] {
       department: "Департамент экономического развития",
       cost: "5000",
       applyUrl: "https://example.com/apply-business",
+      centers: [],
       views: 1200,
       createdAt: new Date("2023-02-10"),
       updatedAt: new Date("2023-07-15"),
@@ -107,6 +112,7 @@ function getMockPopularServices(): Service[] {
       department: "Департамент транспорта",
       cost: "2000",
       applyUrl: "https://example.com/apply-license",
+      centers: [],
       views: 1000,
       createdAt: new Date("2023-03-05"),
       updatedAt: new Date("2023-08-10"),
@@ -121,6 +127,7 @@ function getMockPopularServices(): Service[] {
       department: "Департамент имущественных отношений",
       cost: "3000",
       applyUrl: "https://example.com/apply-property",
+      centers: [],
       views: 900,
       createdAt: new Date("2023-04-20"),
       updatedAt: new Date("2023-09-05"),
@@ -141,6 +148,7 @@ function getMockServices(): Service[] {
       department: "Департамент строительства",
       cost: "10000",
       applyUrl: "https://example.com/apply-building",
+      centers: [],
       views: 800,
       createdAt: new Date("2023-05-15"),
       updatedAt: new Date("2023-10-01"),
@@ -155,6 +163,7 @@ function getMockServices(): Service[] {
       department: "Департамент ЗАГС",
       cost: "500",
       applyUrl: "https://example.com/apply-marriage",
+      centers: [],
       views: 700,
       createdAt: new Date("2023-06-10"),
       updatedAt: new Date("2023-11-05"),

--- a/types/service.ts
+++ b/types/service.ts
@@ -8,6 +8,7 @@ export interface Service {
   department: string
   cost: string
   applyUrl?: string
+  centers: string[]
   views: number
   createdAt: Date
   updatedAt: Date


### PR DESCRIPTION
## Summary
- support centers array on `Service`
- fetch centers in service helpers
- display centers on the service page
- allow editing centers in admin forms

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68431b0fd7bc8331aa5d0c0abac828e8