### PR TITLE
Implement chat search feature

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { getAllServices } from '@/lib/services'
+import { getAllNews } from '@/lib/news'
+import { getAllJobs } from '@/lib/jobs'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const query = (searchParams.get('q') || '').toLowerCase()
+
+  if (!query) {
+    return NextResponse.json({ services: [], news: [], jobs: [] })
+  }
+
+  const [services, news, jobs] = await Promise.all([
+    getAllServices(),
+    getAllNews(),
+    getAllJobs(),
+  ])
+
+  const filter = (text: string) => text.toLowerCase().includes(query)
+
+  const foundServices = services.filter(
+    s => filter(s.title) || filter(s.description)
+  ).slice(0, 3)
+
+  const foundNews = news.filter(
+    n => filter(n.title) || filter(n.summary)
+  ).slice(0, 3)
+
+  const foundJobs = jobs.filter(
+    j => filter(j.title) || filter(j.description)
+  ).slice(0, 3)
+
+  return NextResponse.json({ services: foundServices, news: foundNews, jobs: foundJobs })
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,109 +3,10 @@
 import { getPopularServices } from "@/lib/services"
 import ServiceCard from "@/components/service-card"
 import Image from "next/image"
-import { useState, useRef, type FormEvent } from "react"
+
 import Link from "next/link"
+import ChatBot from "@/components/chat-bot"
 
-type Message = {
-  text: string
-  isUser: boolean
-}
-
-function ChatComponent() {
-  const [messages, setMessages] = useState<Message[]>([
-    { text: "Здравствуйте! Я виртуальный помощник портала E-Davis. Чем могу помочь?", isUser: false },
-  ])
-  const [inputValue, setInputValue] = useState("")
-  const [chatHeight, setChatHeight] = useState(300)
-  const messagesEndRef = useRef<HTMLDivElement>(null)
-
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault()
-    if (!inputValue.trim()) return
-
-    // Добавляем сообщение пользователя
-    const newMessages = [...messages, { text: inputValue, isUser: true }]
-    setMessages(newMessages)
-    setInputValue("")
-
-    // Увеличиваем высоту чата при необходимости
-    if (newMessages.length > 3 && chatHeight < 500) {
-      setChatHeight((prev) => prev + 50)
-    }
-
-    // Имитация ответа бота
-    setTimeout(() => {
-      setMessages((prev) => [...prev, { text: "Спасибо за ваше сообщение! Чем еще я могу помочь?", isUser: false }])
-      // Прокрутка вниз
-      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-    }, 1000)
-  }
-
-  return (
-    <div className="relative w-96 transition-all duration-300">
-      <div
-        className="bg-white rounded-lg p-4 shadow-lg border border-gray-200 mb-4 relative"
-        style={{ maxHeight: `${chatHeight}px` }}
-      >
-        <div className="absolute bottom-0 right-4 w-4 h-4 bg-white transform rotate-45 translate-y-2"></div>
-
-        <div className="flex justify-between items-center mb-4">
-          <h3 className="font-bold text-lg flex items-center">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5 mr-2 text-blue-600"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z"
-                clipRule="evenodd"
-              />
-            </svg>
-            Чат с помощником
-          </h3>
-        </div>
-
-        <div className="overflow-y-auto space-y-3 mb-4" style={{ maxHeight: `${chatHeight - 120}px` }}>
-          {messages.map((msg, index) => (
-            <div
-              key={index}
-              className={`${
-                msg.isUser ? "bg-blue-600 text-white ml-auto" : "bg-gray-100 text-gray-800 mr-auto"
-              } rounded-lg p-3 max-w-[80%]`}
-            >
-              <p className="text-sm">{msg.text}</p>
-            </div>
-          ))}
-          <div ref={messagesEndRef} />
-        </div>
-
-        <form onSubmit={handleSubmit} className="flex items-center gap-2">
-          <input
-            type="text"
-            placeholder="Введите сообщение..."
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            className="flex-1 border rounded-l-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500"
-          />
-          <button
-            type="submit"
-            className="bg-blue-600 text-white px-3 py-2 rounded-r-lg hover:bg-blue-700 transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-              <path
-                fillRule="evenodd"
-                d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </button>
-        </form>
-      </div>
-    </div>
-  )
-}
 
 export default async function Home() {
   const popularServices = await getPopularServices()
@@ -127,13 +28,7 @@ export default async function Home() {
               <p className="text-xl text-gray-600 mb-8">Все нужное теперь на одном портале</p>
             </div>
             <div className="relative flex justify-start">
-              <ChatComponent />
-
-              <div className="flex justify-start mt-4">
-                <div className="pointer-events-none">
-                  <Image src="/images/robot-assistant.svg" alt="Виртуальный помощник" width={300} height={300} />
-                </div>
-              </div>
+              <ChatBot />
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- enable search API endpoint for chat assistant
- enhance chat-bot component to display search results
- use ChatBot on the homepage

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432ba0f9248331bd405413a1d6e724