### PR TITLE
Implement search-enabled chat assistant

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import ServiceCard from "@/components/service-card"
 import Image from "next/image"
 import { useState, useRef, type FormEvent } from "react"
 import Link from "next/link"
+import { searchSite } from "@/lib/search"
 
 type Message = {
   text: string
@@ -18,13 +19,16 @@ function ChatComponent() {
   const [inputValue, setInputValue] = useState("")
   const [chatHeight, setChatHeight] = useState(300)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const [loading, setLoading] = useState(false)
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     if (!inputValue.trim()) return
 
+    const userText = inputValue
+
     // Добавляем сообщение пользователя
-    const newMessages = [...messages, { text: inputValue, isUser: true }]
+    const newMessages = [...messages, { text: userText, isUser: true }]
     setMessages(newMessages)
     setInputValue("")
 
@@ -33,12 +37,18 @@ function ChatComponent() {
       setChatHeight((prev) => prev + 50)
     }
 
-    // Имитация ответа бота
-    setTimeout(() => {
-      setMessages((prev) => [...prev, { text: "Спасибо за ваше сообщение! Чем еще я могу помочь?", isUser: false }])
-      // Прокрутка вниз
-      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-    }, 1000)
+    setLoading(true)
+    const results = await searchSite(userText)
+    setLoading(false)
+
+    const answer =
+      results.length > 0
+        ? `Вот что я нашел:\n- ${results.slice(0, 5).join("\n- ")}`
+        : "К сожалению, я ничего не нашел."
+
+    setMessages((prev) => [...prev, { text: answer, isUser: false }])
+    // Прокрутка вниз
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
   }
 
   return (
@@ -73,11 +83,17 @@ function ChatComponent() {
               key={index}
               className={`${
                 msg.isUser ? "bg-blue-600 text-white ml-auto" : "bg-gray-100 text-gray-800 mr-auto"
-              } rounded-lg p-3 max-w-[80%]`}
+              } rounded-lg p-3 max-w-[80%] animate-in fade-in slide-in-from-bottom-2`}
             >
               <p className="text-sm">{msg.text}</p>
             </div>
           ))}
+          {loading && (
+            <div className="flex items-center gap-2 text-gray-500 text-sm">
+              <span>Поиск...</span>
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
+            </div>
+          )}
           <div ref={messagesEndRef} />
         </div>
 

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,46 @@
+import { getAllServices } from "@/lib/services"
+import { getAllFaqs } from "@/lib/faq"
+import { getAllNews } from "@/lib/news"
+import { getAllJobs } from "@/lib/jobs"
+
+/**
+ * Search across services, news, jobs and FAQs.
+ * Returns an array of strings describing found items.
+ */
+export async function searchSite(query: string): Promise<string[]> {
+  const q = query.toLowerCase()
+  const [services, news, jobs, faqs] = await Promise.all([
+    getAllServices(),
+    getAllNews(),
+    getAllJobs(),
+    getAllFaqs(),
+  ])
+
+  const results: string[] = []
+
+  services.forEach((s) => {
+    if (s.title.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)) {
+      results.push(`Услуга: ${s.title}`)
+    }
+  })
+
+  news.forEach((n) => {
+    if (n.title.toLowerCase().includes(q) || n.summary.toLowerCase().includes(q)) {
+      results.push(`Новость: ${n.title}`)
+    }
+  })
+
+  jobs.forEach((j) => {
+    if (j.title.toLowerCase().includes(q) || j.description.toLowerCase().includes(q)) {
+      results.push(`Вакансия: ${j.title}`)
+    }
+  })
+
+  faqs.forEach((f) => {
+    if (f.question.toLowerCase().includes(q) || f.answer.toLowerCase().includes(q)) {
+      results.push(`FAQ: ${f.question}`)
+    }
+  })
+
+  return results
+}


### PR DESCRIPTION
## Summary
- implement `searchSite` helper to search services, jobs, FAQs, and news
- upgrade home page chat component to use search results
- show spinner while searching and animate messages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68432e531f688331bd4d7d794a511e6f