### PR TITLE
Improve chat assistant stability

### DIFF
--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,51 @@
+import { getAllServices } from "@/lib/services"
+import { getAllFaqs } from "@/lib/faq"
+import { getAllNews } from "@/lib/news"
+import { getAllJobs } from "@/lib/jobs"
+
+/**
+ * Search across services, news, jobs and FAQs.
+ * Returns an array of strings describing found items.
+ */
+export async function searchSite(query: string): Promise<string[]> {
+  const q = query.toLowerCase()
+  try {
+    const [services, news, jobs, faqs] = await Promise.all([
+      getAllServices(),
+      getAllNews(),
+      getAllJobs(),
+      getAllFaqs(),
+    ])
+
+    const results: string[] = []
+
+    services.forEach((s) => {
+      if (s.title.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)) {
+        results.push(`Услуга: ${s.title}`)
+      }
+    })
+
+    news.forEach((n) => {
+      if (n.title.toLowerCase().includes(q) || n.summary.toLowerCase().includes(q)) {
+        results.push(`Новость: ${n.title}`)
+      }
+    })
+
+    jobs.forEach((j) => {
+      if (j.title.toLowerCase().includes(q) || j.description.toLowerCase().includes(q)) {
+        results.push(`Вакансия: ${j.title}`)
+      }
+    })
+
+    faqs.forEach((f) => {
+      if (f.question.toLowerCase().includes(q) || f.answer.toLowerCase().includes(q)) {
+        results.push(`FAQ: ${f.question}`)
+      }
+    })
+
+    return results
+  } catch (error) {
+    console.error('searchSite error:', error)
+    return []
+  }
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,5 +1,8 @@
 import { createClient as createSupabaseClient } from "@supabase/supabase-js"
 
+// Keep a single instance to avoid GoTrue warnings in the browser
+let browserClient: ReturnType<typeof createSupabaseClient> | null = null
+
 export function createClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
@@ -50,5 +53,8 @@ export function createClient() {
     } as any
   }
 
-  return createSupabaseClient(supabaseUrl, supabaseKey)
+  if (browserClient) return browserClient
+
+  browserClient = createSupabaseClient(supabaseUrl, supabaseKey)
+  return browserClient
 }


### PR DESCRIPTION
## Summary
- reuse a single Supabase client instance to stop GoTrue warnings
- add error handling and scrolling to chat
- handle search errors gracefully

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68432e531f688331bd4d7d794a511e6f