### PR TITLE
Improve chat assistant stability

### DIFF
--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -1,7 +1,10 @@
 import type { Faq } from "@/types/faq"
 import { createClient } from "@/lib/supabase/client"
 
+let allFaqsCache: Faq[] | null = null
+
 export async function getAllFaqs(): Promise<Faq[]> {
+  if (allFaqsCache) return allFaqsCache
   try {
     const supabase = createClient()
 
@@ -12,19 +15,22 @@ export async function getAllFaqs(): Promise<Faq[]> {
 
     if (error) {
       console.error("Error fetching faq:", error)
-      return getMockFaqs()
+      allFaqsCache = getMockFaqs()
+      return allFaqsCache
     }
 
-    return data.map((item: any) => ({
+    allFaqsCache = data.map((item: any) => ({
       id: item.id,
       question: item.question,
       answer: item.answer,
       createdAt: new Date(item.created_at),
       updatedAt: new Date(item.updated_at),
     })) as Faq[]
+    return allFaqsCache
   } catch (error) {
     console.error("Error fetching faq:", error)
-    return getMockFaqs()
+    allFaqsCache = getMockFaqs()
+    return allFaqsCache
   }
 }
 

--- a/lib/jobs.ts
+++ b/lib/jobs.ts
@@ -1,6 +1,8 @@
 import type { Job } from "@/types/job"
 import { createClient } from "@/lib/supabase/client"
 
+let allJobsCache: Job[] | null = null
+
 export async function getLatestJobs(limit = 5): Promise<Job[]> {
   try {
     const supabase = createClient()
@@ -42,20 +44,27 @@ export async function getJobById(id: string): Promise<Job | null> {
 }
 
 export async function getAllJobs(): Promise<Job[]> {
+  if (allJobsCache) return allJobsCache
   try {
     const supabase = createClient()
 
-    const { data, error } = await supabase.from("jobs").select("*").order("published_at", { ascending: false })
+    const { data, error } = await supabase
+      .from("jobs")
+      .select("*")
+      .order("published_at", { ascending: false })
 
     if (error) {
       console.error("Error fetching all jobs:", error)
-      return getMockJobs()
+      allJobsCache = getMockJobs()
+      return allJobsCache
     }
 
-    return data as Job[]
+    allJobsCache = data as Job[]
+    return allJobsCache
   } catch (error) {
     console.error("Error fetching all jobs:", error)
-    return getMockJobs()
+    allJobsCache = getMockJobs()
+    return allJobsCache
   }
 }
 

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,51 @@
+import { getAllServices } from "@/lib/services"
+import { getAllFaqs } from "@/lib/faq"
+import { getAllNews } from "@/lib/news"
+import { getAllJobs } from "@/lib/jobs"
+
+/**
+ * Search across services, news, jobs and FAQs.
+ * Returns an array of strings describing found items.
+ */
+export async function searchSite(query: string): Promise<string[]> {
+  const q = query.toLowerCase()
+  try {
+    const [services, news, jobs, faqs] = await Promise.all([
+      getAllServices(),
+      getAllNews(),
+      getAllJobs(),
+      getAllFaqs(),
+    ])
+
+    const results: string[] = []
+
+    services.forEach((s) => {
+      if (s.title.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)) {
+        results.push(`Услуга: ${s.title}`)
+      }
+    })
+
+    news.forEach((n) => {
+      if (n.title.toLowerCase().includes(q) || n.summary.toLowerCase().includes(q)) {
+        results.push(`Новость: ${n.title}`)
+      }
+    })
+
+    jobs.forEach((j) => {
+      if (j.title.toLowerCase().includes(q) || j.description.toLowerCase().includes(q)) {
+        results.push(`Вакансия: ${j.title}`)
+      }
+    })
+
+    faqs.forEach((f) => {
+      if (f.question.toLowerCase().includes(q) || f.answer.toLowerCase().includes(q)) {
+        results.push(`FAQ: ${f.question}`)
+      }
+    })
+
+    return results
+  } catch (error) {
+    console.error('searchSite error:', error)
+    return []
+  }
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,5 +1,11 @@
 import { createClient as createSupabaseClient } from "@supabase/supabase-js"
 
+// Use a global variable so hot reloads don't create extra clients
+declare global {
+  // eslint-disable-next-line no-var
+  var __supabaseClient: ReturnType<typeof createSupabaseClient> | undefined
+}
+
 export function createClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
@@ -50,5 +56,13 @@ export function createClient() {
     } as any
   }
 
+  if (typeof window !== "undefined") {
+    if (!globalThis.__supabaseClient) {
+      globalThis.__supabaseClient = createSupabaseClient(supabaseUrl, supabaseKey)
+    }
+    return globalThis.__supabaseClient
+  }
+
+  // On the server we can create a new client per request
   return createSupabaseClient(supabaseUrl, supabaseKey)
 }


### PR DESCRIPTION
## Summary
- reuse a single Supabase client instance to stop GoTrue warnings
- cache site data to avoid repeated failed requests

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68432e531f688331bd4d7d794a511e6f