### PR TITLE
Dark theme redesign

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,6 @@
 
 body {
   font-family: "PT Sans Caption", sans-serif;
-  background-color: #e6f0fa;
 }
 
 @layer utilities {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           rel="stylesheet"
         />
       </head>
-      <body>
+      <body className="bg-gradient-to-br from-slate-900 to-purple-900 text-white min-h-screen">
         <Header />
         <main>{children}</main>
         <Footer />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,12 +55,11 @@ function ChatComponent() {
   }
 
   return (
-    <div className="relative w-96 transition-all duration-300">
+    <div className="w-96 transition-all duration-300">
       <div
-        className="bg-white rounded-lg p-4 shadow-lg border border-gray-200 mb-4 relative"
+        className="bg-slate-800 text-white rounded-xl p-4 shadow-lg mb-4"
         style={{ maxHeight: `${chatHeight}px` }}
       >
-        <div className="absolute bottom-0 right-4 w-4 h-4 bg-white transform rotate-45 translate-y-2"></div>
 
         <div className="flex justify-between items-center mb-4">
           <h3 className="font-bold text-lg flex items-center">
@@ -85,7 +84,7 @@ function ChatComponent() {
             <div
               key={index}
               className={`${
-                msg.isUser ? "bg-blue-600 text-white ml-auto" : "bg-gray-100 text-gray-800 mr-auto"
+                msg.isUser ? "bg-blue-600 text-white ml-auto" : "bg-slate-700 text-white mr-auto"
               } rounded-lg p-3 max-w-[80%] animate-in fade-in slide-in-from-bottom-2`}
             >
               <p className="text-sm">{msg.text}</p>
@@ -106,7 +105,7 @@ function ChatComponent() {
             placeholder="Введите сообщение..."
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
-            className="flex-1 border rounded-l-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="flex-1 bg-slate-900 border border-slate-700 text-white rounded-l-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
           <button
             type="submit"
@@ -130,26 +129,26 @@ export default async function Home() {
   const popularServices = await getPopularServices()
 
   return (
-    <div className="min-h-screen bg-[#e6f0fa]">
+    <div className="min-h-screen">
       <div className="container mx-auto px-4 py-8">
         {/* Hero Section */}
         <section className="py-8">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
             <div>
-              <h1 className="text-4xl md:text-5xl font-bold text-[#2d3748] leading-tight mb-6">
+              <h1 className="text-white text-5xl font-bold drop-shadow-md mb-6">
                 Добро пожаловать
                 <br />
                 на портал услуг штата
                 <br />
                 Davis
               </h1>
-              <p className="text-xl text-gray-600 mb-8">Все нужное теперь на одном портале</p>
+              <p className="text-slate-300 text-lg mb-8">Все нужное теперь на одном портале</p>
             </div>
             <div className="relative flex justify-start">
               <ChatComponent />
 
               <div className="flex justify-start mt-4">
-                <div className="pointer-events-none">
+                <div className="pointer-events-none drop-shadow-2xl">
                   <Image src="/images/robot-assistant.svg" alt="Виртуальный помощник" width={300} height={300} />
                 </div>
               </div>
@@ -158,18 +157,17 @@ export default async function Home() {
         </section>
       </div>
 
-      {/* White background section starting from middle of service icons */}
-      <div className="bg-white pt-20 pb-12 -mt-16">
+      <div className="pt-20 pb-12 -mt-16">
         <div className="container mx-auto px-4">
           {/* Service Categories */}
           <section className="grid grid-cols-1 md:grid-cols-3 gap-6 -mt-32">
             <Link
               href="/services"
-              className="block bg-white rounded-lg p-6 text-center shadow-sm hover:shadow-md transition-shadow"
+              className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300 text-center"
             >
-              <div className="w-20 h-20 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <svg
-                  className="text-white h-10 w-10"
+                  className="w-12 h-12 mx-auto"
                   viewBox="0 0 24 24"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -183,16 +181,16 @@ export default async function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="text-xl font-medium text-[#2d3748]">Услуги</h3>
+              <h3 className="text-xl font-bold drop-shadow">Услуги</h3>
             </Link>
 
             <Link
               href="/jobs"
-              className="block bg-white rounded-lg p-6 text-center shadow-sm hover:shadow-md transition-shadow"
+              className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300 text-center"
             >
-              <div className="w-20 h-20 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <svg
-                  className="text-white h-10 w-10"
+                  className="w-12 h-12 mx-auto"
                   viewBox="0 0 24 24"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -213,16 +211,16 @@ export default async function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="text-xl font-medium text-[#2d3748]">Вакансии</h3>
+              <h3 className="text-xl font-bold drop-shadow">Вакансии</h3>
             </Link>
 
             <Link
               href="/faq"
-              className="block bg-white rounded-lg p-6 text-center shadow-sm hover:shadow-md transition-shadow"
+              className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300 text-center"
             >
-              <div className="w-20 h-20 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <svg
-                  className="text-white h-10 w-10"
+                  className="w-12 h-12 mx-auto"
                   viewBox="0 0 24 24"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -244,15 +242,15 @@ export default async function Home() {
                 </svg>
               </div>
               <div className="text-center">
-                <p className="text-lg text-[#2d3748]">Часто задаваемые</p>
-                <p className="text-lg text-[#2d3748]">вопросы!</p>
+                <p className="text-lg">Часто задаваемые</p>
+                <p className="text-lg">вопросы!</p>
               </div>
             </Link>
           </section>
 
           {/* Popular Services */}
           <section className="py-12">
-            <h2 className="text-2xl font-bold text-[#2d3748] mb-6">Популярные услуги</h2>
+            <h2 className="text-2xl font-bold text-white mb-6 drop-shadow">Популярные услуги</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-4xl mx-auto">
               {popularServices.slice(0, 4).map((service) => (
                 <ServiceCard key={service.id} service={service} />

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,83 +3,83 @@ import Image from "next/image"
 
 export function Footer() {
   return (
-    <footer className="py-6 bg-[#e6f0fa] mt-12">
-      <div className="container mx-auto px-4">
+    <footer className="py-6 mt-12">
+      <div className="container mx-auto px-4 text-white">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div>
             <h3 className="font-bold text-lg mb-4">E-Davis</h3>
-            <p className="text-gray-600">Официальный портал услуг штата Davis</p>
+            <p className="text-slate-300">Официальный портал услуг штата Davis</p>
           </div>
           <div>
-            <h4 className="font-medium mb-4 text-gray-600">Услуги</h4>
+            <h4 className="font-medium mb-4 text-slate-300">Услуги</h4>
             <ul className="space-y-2">
               <li>
-                <Link href="/services" className="hover:text-blue-200 text-gray-600">
+                <Link href="/services" className="hover:text-blue-400 text-slate-300">
                   Все услуги
                 </Link>
               </li>
               <li>
-                <Link href="/services/popular" className="hover:text-blue-200 text-gray-600">
+                <Link href="/services/popular" className="hover:text-blue-400 text-slate-300">
                   Популярные услуги
                 </Link>
               </li>
               <li>
-                <Link href="/services/new" className="hover:text-blue-200 text-gray-600">
+                <Link href="/services/new" className="hover:text-blue-400 text-slate-300">
                   Новые услуги
                 </Link>
               </li>
             </ul>
           </div>
           <div>
-            <h4 className="font-medium mb-4 text-gray-600">Информация</h4>
+            <h4 className="font-medium mb-4 text-slate-300">Информация</h4>
             <ul className="space-y-2">
               <li>
-                <Link href="/about" className="hover:text-blue-200 text-gray-600">
+                <Link href="/about" className="hover:text-blue-400 text-slate-300">
                   О правительстве
                 </Link>
               </li>
               <li>
-                <Link href="/news" className="hover:text-blue-200 text-gray-600">
+                <Link href="/news" className="hover:text-blue-400 text-slate-300">
                   Новости
                 </Link>
               </li>
               <li>
-                <Link href="/jobs" className="hover:text-blue-200 text-gray-600">
+                <Link href="/jobs" className="hover:text-blue-400 text-slate-300">
                   Вакансии
                 </Link>
               </li>
               <li>
-                <Link href="/important" className="hover:text-blue-200 text-gray-600">
+                <Link href="/important" className="hover:text-blue-400 text-slate-300">
                   Важная информация
                 </Link>
               </li>
             </ul>
           </div>
           <div>
-            <h4 className="font-medium mb-4 text-gray-600">Поддержка</h4>
+            <h4 className="font-medium mb-4 text-slate-300">Поддержка</h4>
             <ul className="space-y-2">
               <li>
-                <Link href="/faq" className="hover:text-blue-200 text-gray-600">
+                <Link href="/faq" className="hover:text-blue-400 text-slate-300">
                   Часто задаваемые вопросы
                 </Link>
               </li>
               <li>
-                <Link href="/contacts" className="hover:text-blue-200 text-gray-600">
+                <Link href="/contacts" className="hover:text-blue-400 text-slate-300">
                   Контакты
                 </Link>
               </li>
               <li>
-                <Link href="/feedback" className="hover:text-blue-200 text-gray-600">
+                <Link href="/feedback" className="hover:text-blue-400 text-slate-300">
                   Обратная связь
                 </Link>
               </li>
             </ul>
           </div>
         </div>
-        <div className="mt-8 flex justify-center">
+        <div className="mt-8 flex justify-center drop-shadow-2xl">
           <Image src="/images/robot-assistant.svg" alt="E-Davis Robot" width={40} height={40} />
         </div>
-        <div className="mt-8 text-center text-gray-600">
+        <div className="mt-8 text-center text-slate-300">
           <p className="text-sm">© 2025 E-Davis. Все права защищены.</p>
         </div>
       </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,27 +8,24 @@ export function Header() {
   const pathname = usePathname()
 
   return (
-    <header className="py-4 bg-[#e6f0fa]">
+    <header className="py-4">
       <div className="container mx-auto px-4 flex items-center justify-between">
-        <Link href="/" className="text-[#2d3748] text-3xl font-bold">
+        <Link href="/" className="text-white text-3xl font-bold drop-shadow">
           E-Davis
         </Link>
 
-        <nav className="flex items-center space-x-8">
-          <Link href="/services" className="text-[#2d3748]">
+        <nav className="flex items-center space-x-8 text-white">
+          <Link href="/services" className="hover:text-blue-400">
             Услуги
           </Link>
-          <Link href="/news" className="text-[#2d3748]">
+          <Link href="/news" className="hover:text-blue-400">
             Новости
           </Link>
-          <Link href="/news" className="text-[#2d3748]">
-            Новости
-          </Link>
-          <Link href="/jobs" className="text-[#2d3748]">
+          <Link href="/jobs" className="hover:text-blue-400">
             Вакансии
           </Link>
           <div className="relative group">
-            <button className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-full transition-colors flex items-center gap-2">
+            <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-full shadow-md transition flex items-center gap-2">
               О правительстве
               <ChevronDown className="h-4 w-4 transition-transform group-hover:rotate-180" />
             </button>

--- a/components/service-card.tsx
+++ b/components/service-card.tsx
@@ -1,6 +1,4 @@
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { ArrowRight, Clock, FileText } from "lucide-react"
+import { ArrowRight, FileText } from "lucide-react"
 import Link from "next/link"
 import type { Service } from "@/types/service"
 
@@ -10,24 +8,19 @@ interface ServiceCardProps {
 
 export default function ServiceCard({ service }: ServiceCardProps) {
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader className="flex flex-row items-start gap-4 pb-2">
-        <div className="p-2 bg-primary/10 rounded-md">
-          <FileText className="h-5 w-5 text-primary" />
+    <div className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300 flex flex-col">
+      <div className="flex items-start gap-4 pb-4">
+        <FileText className="w-12 h-12" />
+        <div>
+          <h3 className="text-xl font-bold drop-shadow mb-2">{service.title}</h3>
+          <p className="text-sm text-slate-200 line-clamp-2">{service.description}</p>
         </div>
-        <div className="grid gap-1">
-          <CardTitle className="text-lg">{service.title}</CardTitle>
-          <CardDescription className="line-clamp-2">{service.description}</CardDescription>
-        </div>
-      </CardHeader>
-
-      <CardFooter className="mt-auto pt-2">
-        <Button asChild variant="ghost" className="w-full justify-between">
-          <Link href={`/services/${service.id}`}>
-            Подробнее <ArrowRight className="h-4 w-4" />
-          </Link>
-        </Button>
-      </CardFooter>
-    </Card>
+      </div>
+      <div className="mt-auto pt-4">
+        <Link href={`/services/${service.id}`} className="underline flex items-center gap-1 hover:text-blue-300">
+          Подробнее <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- modernize layout with dark gradient background
- style header and footer links for dark theme
- redesign service cards and home page sections
- adjust robot mascot and chat component look

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843642d5d488331993ed36e05023e2d