### PR TITLE
Dark theme redesign

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,6 @@
 
 body {
   font-family: "PT Sans Caption", sans-serif;
-  background-color: #e6f0fa;
 }
 
 @layer utilities {

--- a/app/goverment/capitol-plan/page.tsx
+++ b/app/goverment/capitol-plan/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next"
 import Image from "next/image"
-import { Card, CardContent } from "@/components/ui/card"
 
 export const metadata: Metadata = {
   title: "План капитолия | E-Davis",
@@ -65,38 +64,37 @@ export default function CapitolPlanPage() {
 
   return (
     <div className="container mx-auto py-8 px-4">
-      <h1 className="text-3xl font-bold mb-8 text-center">План капитолия</h1>
+      <h1 className="text-3xl font-bold text-white drop-shadow mb-8 text-center">План капитолия</h1>
 
       <div className="space-y-12">
         {floorPlans.map((floor) => (
-          <Card key={floor.id} className="overflow-hidden">
-            <CardContent className="p-0">
-              <div className="flex flex-col lg:flex-row">
-                <div className="lg:w-1/2 relative">
-                  <div className="aspect-[3/2] relative">
-                    <Image
-                      src={floor.image || "/placeholder.svg"}
-                      alt={`План ${floor.title}`}
-                      fill
-                      className="object-cover"
-                    />
-                  </div>
-                </div>
-                <div className="lg:w-1/2 p-6">
-                  <h2 className="text-2xl font-bold mb-4">{floor.title}</h2>
-                  <div className="bg-gray-50 p-4 rounded-lg">
-                    <ul className="space-y-2">
-                      {floor.rooms.map((room, index) => (
-                        <li key={index} className="flex">
-                          <span className="font-medium">{room}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
+          <div
+            key={floor.id}
+            className="bg-gradient-to-br from-blue-700 to-purple-700 text-white rounded-xl shadow-xl overflow-hidden"
+          >
+            <div className="flex flex-col lg:flex-row">
+              <div className="lg:w-1/2 relative">
+                <div className="aspect-[3/2] relative">
+                  <Image
+                    src={floor.image || "/placeholder.svg"}
+                    alt={`План ${floor.title}`}
+                    fill
+                    className="object-cover rounded-t-xl lg:rounded-r-none lg:rounded-l-xl"
+                  />
                 </div>
               </div>
-            </CardContent>
-          </Card>
+              <div className="lg:w-1/2 p-6">
+                <h2 className="text-2xl font-bold mb-4 drop-shadow">{floor.title}</h2>
+                <ul className="space-y-2 text-slate-200">
+                  {floor.rooms.map((room, index) => (
+                    <li key={index} className="flex">
+                      <span>{room}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
         ))}
       </div>
     </div>

--- a/app/goverment/layout.tsx
+++ b/app/goverment/layout.tsx
@@ -11,5 +11,9 @@ export default function GovernmentLayout({
 }: {
   children: React.ReactNode
 }) {
-  return <div className="min-h-screen bg-gray-50">{children}</div>
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 to-purple-900 text-white">
+      {children}
+    </div>
+  )
 }

--- a/app/goverment/members/page.tsx
+++ b/app/goverment/members/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next"
 import Image from "next/image"
 import { getGovernmentMembers } from "@/lib/government"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
 import { Badge } from "@/components/ui/badge"
 
 export const metadata: Metadata = {
@@ -17,15 +17,15 @@ export default async function GovernmentMembersPage() {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-4">Состав правительства</h1>
-        <p className="text-muted-foreground">Актуальная информация о составе правительства и руководящих должностях</p>
+        <h1 className="text-3xl font-bold text-white drop-shadow mb-4">Состав правительства</h1>
+        <p className="text-slate-300">Актуальная информация о составе правительства и руководящих должностях</p>
       </div>
 
       {governor && (
         <div className="mb-12">
-          <h2 className="text-2xl font-semibold mb-6">Губернатор</h2>
-          <Card className="max-w-md">
-            <CardHeader className="text-center">
+          <h2 className="text-2xl font-semibold text-white drop-shadow mb-6">Губернатор</h2>
+          <div className="max-w-md bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl">
+            <div className="text-center">
               <div className="mx-auto mb-4">
                 {governor.photo_url ? (
                   <Image
@@ -41,34 +41,33 @@ export default async function GovernmentMembersPage() {
                   </div>
                 )}
               </div>
-              <CardTitle className="text-xl">{governor.full_name}</CardTitle>
-            </CardHeader>
-            <CardContent className="text-center">
+              <h3 className="text-xl font-bold drop-shadow mb-2">{governor.full_name}</h3>
+            </div>
+            <div className="text-center">
               <Badge variant="secondary" className="mb-2">
                 {governor.position}
               </Badge>
-              <p className="text-muted-foreground">{governor.department}</p>
-            </CardContent>
-          </Card>
+              <p className="text-slate-300">{governor.department}</p>
+            </div>
+          </div>
         </div>
       )}
 
       {otherMembers.length > 0 && (
         <div>
-          <h2 className="text-2xl font-semibold mb-6">Члены правительства</h2>
+          <h2 className="text-2xl font-semibold text-white drop-shadow mb-6">Члены правительства</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {otherMembers.map((member) => (
-              <Card key={member.id}>
-                <CardHeader>
-                  <CardTitle className="text-lg">{member.full_name}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <Badge variant="outline" className="mb-2">
-                    {member.position}
-                  </Badge>
-                  <p className="text-muted-foreground text-sm">{member.department}</p>
-                </CardContent>
-              </Card>
+              <div
+                key={member.id}
+                className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl"
+              >
+                <h3 className="text-lg font-bold drop-shadow mb-2">{member.full_name}</h3>
+                <Badge variant="outline" className="mb-2">
+                  {member.position}
+                </Badge>
+                <p className="text-slate-300 text-sm">{member.department}</p>
+              </div>
             ))}
           </div>
         </div>
@@ -76,7 +75,7 @@ export default async function GovernmentMembersPage() {
 
       {members.length === 0 && (
         <div className="text-center py-12">
-          <p className="text-muted-foreground">Информация о составе правительства пока не добавлена.</p>
+          <p className="text-slate-300">Информация о составе правительства пока не добавлена.</p>
         </div>
       )}
     </div>

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -33,13 +33,13 @@ export default async function JobsPage() {
     <div className="container mx-auto px-4 py-8">
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
         <div>
-          <h1 className="text-3xl font-bold mb-2">Вакансии</h1>
-          <p className="text-muted-foreground">Актуальные вакансии в государственных учреждениях E-Davis</p>
+          <h1 className="text-3xl font-bold text-white drop-shadow mb-2">Вакансии</h1>
+          <p className="text-slate-300">Актуальные вакансии в государственных учреждениях E-Davis</p>
         </div>
       </div>
 
       <Tabs defaultValue="all" className="w-full">
-        <TabsList className="mb-8 flex flex-wrap h-auto">
+        <TabsList className="mb-8 flex flex-wrap h-auto bg-slate-800/50 rounded-lg p-1">
           <TabsTrigger value="all">Все вакансии</TabsTrigger>
           {departments.map((department) => (
             <TabsTrigger key={department} value={department}>
@@ -51,39 +51,33 @@ export default async function JobsPage() {
         <TabsContent value="all">
           <div className="grid grid-cols-1 gap-6">
             {jobs.map((job) => (
-              <Card key={job.id}>
-                <CardHeader>
-                  <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                    <div>
-                      <CardTitle className="text-xl">{job.title}</CardTitle>
-                      <CardDescription className="flex items-center mt-2">
-                        <Building className="h-4 w-4 mr-1" />
-                        {job.department}
-                      </CardDescription>
-                    </div>
-                    <div className="text-lg font-medium">{job.salary} $</div>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-                    <div className="flex items-center text-sm text-muted-foreground">
-                      <MapPin className="h-4 w-4 mr-1" />
-                      {job.location}
-                    </div>
-                    <div className="flex items-center text-sm text-muted-foreground">
-                      <Briefcase className="h-4 w-4 mr-1" />
-                      {job.type}
-                    </div>
-                  </div>
-
-                  <p className="text-muted-foreground mb-4">{job.description}</p>
-
+              <div
+                key={job.id}
+                className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl"
+              >
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4">
                   <div>
-                    <h4 className="font-medium mb-2">Требования:</h4>
-                    <p className="text-muted-foreground">{job.requirements}</p>
+                    <h3 className="text-xl font-bold drop-shadow">{job.title}</h3>
+                    <div className="flex items-center mt-2 text-slate-300">
+                      <Building className="h-4 w-4 mr-1" /> {job.department}
+                    </div>
                   </div>
-                </CardContent>
-              </Card>
+                  <div className="text-lg font-medium">{job.salary} $</div>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4 text-slate-300">
+                  <div className="flex items-center text-sm">
+                    <MapPin className="h-4 w-4 mr-1" /> {job.location}
+                  </div>
+                  <div className="flex items-center text-sm">
+                    <Briefcase className="h-4 w-4 mr-1" /> {job.type}
+                  </div>
+                </div>
+                <p className="text-slate-200 mb-4">{job.description}</p>
+                <div>
+                  <h4 className="font-medium mb-2">Требования:</h4>
+                  <p className="text-slate-300">{job.requirements}</p>
+                </div>
+              </div>
             ))}
           </div>
         </TabsContent>
@@ -92,43 +86,36 @@ export default async function JobsPage() {
           <TabsContent key={department} value={department}>
             <div className="grid grid-cols-1 gap-6">
               {jobsByDepartment[department].map((job) => (
-                <Card key={job.id}>
-                  <CardHeader>
-                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                      <div>
-                        <CardTitle className="text-xl">{job.title}</CardTitle>
-                        <CardDescription className="flex items-center mt-2">
-                          <Building className="h-4 w-4 mr-1" />
-                          {job.department}
-                        </CardDescription>
-                      </div>
-                      <div className="text-lg font-medium">{job.salary} $</div>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-                      <div className="flex items-center text-sm text-muted-foreground">
-                        <MapPin className="h-4 w-4 mr-1" />
-                        {job.location}
-                      </div>
-                      <div className="flex items-center text-sm text-muted-foreground">
-                        <Briefcase className="h-4 w-4 mr-1" />
-                        {job.type}
-                      </div>
-                      <div className="flex items-center text-sm text-muted-foreground">
-                        <Calendar className="h-4 w-4 mr-1" />
-                        До {formatDate(job.deadline)}
-                      </div>
-                    </div>
-
-                    <p className="text-muted-foreground mb-4">{job.description}</p>
-
+                <div
+                  key={job.id}
+                  className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl"
+                >
+                  <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4">
                     <div>
-                      <h4 className="font-medium mb-2">Требования:</h4>
-                      <p className="text-muted-foreground">{job.requirements}</p>
+                      <h3 className="text-xl font-bold drop-shadow">{job.title}</h3>
+                      <div className="flex items-center mt-2 text-slate-300">
+                        <Building className="h-4 w-4 mr-1" /> {job.department}
+                      </div>
                     </div>
-                  </CardContent>
-                </Card>
+                    <div className="text-lg font-medium">{job.salary} $</div>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4 text-slate-300">
+                    <div className="flex items-center text-sm">
+                      <MapPin className="h-4 w-4 mr-1" /> {job.location}
+                    </div>
+                    <div className="flex items-center text-sm">
+                      <Briefcase className="h-4 w-4 mr-1" /> {job.type}
+                    </div>
+                    <div className="flex items-center text-sm">
+                      <Calendar className="h-4 w-4 mr-1" /> До {formatDate(job.deadline)}
+                    </div>
+                  </div>
+                  <p className="text-slate-200 mb-4">{job.description}</p>
+                  <div>
+                    <h4 className="font-medium mb-2">Требования:</h4>
+                    <p className="text-slate-300">{job.requirements}</p>
+                  </div>
+                </div>
               ))}
             </div>
           </TabsContent>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ru">
+    <html lang="ru" className="dark">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
@@ -20,7 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           rel="stylesheet"
         />
       </head>
-      <body>
+      <body className="bg-gradient-to-br from-slate-900 to-purple-900 text-white min-h-screen">
         <Header />
         <main>{children}</main>
         <Footer />

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next"
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -34,14 +33,14 @@ export default async function NewsPage() {
     <div className="container mx-auto px-4 py-8">
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
         <div>
-          <h1 className="text-3xl font-bold mb-2">Новости</h1>
-          <p className="text-muted-foreground">Актуальные новости и события E-Davis</p>
+          <h1 className="text-3xl font-bold text-white drop-shadow mb-2">Новости</h1>
+          <p className="text-slate-300">Актуальные новости и события E-Davis</p>
         </div>
 
       </div>
 
       <Tabs defaultValue="all" className="w-full">
-        <TabsList className="mb-8 flex flex-wrap h-auto">
+        <TabsList className="mb-8 flex flex-wrap h-auto bg-slate-800/50 rounded-lg p-1">
           <TabsTrigger value="all">Все новости</TabsTrigger>
           {categories.map((category) => (
             <TabsTrigger key={category} value={category}>
@@ -53,7 +52,10 @@ export default async function NewsPage() {
         <TabsContent value="all">
           <div className="grid grid-cols-1 gap-8">
             {news.map((item) => (
-              <Card key={item.id} className="overflow-hidden">
+              <div
+                key={item.id}
+                className="bg-gradient-to-br from-blue-700 to-purple-700 text-white rounded-xl shadow-xl overflow-hidden hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300"
+              >
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                   <div className="md:col-span-1">
                     <Image
@@ -61,37 +63,31 @@ export default async function NewsPage() {
                       alt={item.title}
                       width={400}
                       height={300}
-                      className="w-full h-full object-cover aspect-video"
+                      className="w-full h-full object-cover rounded-t-xl md:rounded-l-xl md:rounded-r-none"
                     />
                   </div>
                   <div className="md:col-span-2 flex flex-col p-6">
-                    <CardHeader className="p-0 pb-4">
-                      <div className="flex items-center gap-2 mb-2">
-                        <span className="text-sm px-2 py-1 bg-primary/10 text-primary rounded-md flex items-center">
-                          <Tag className="h-3 w-3 mr-1" />
-                          {item.category}
+                    <div className="mb-4">
+                      <div className="flex items-center gap-2 mb-2 text-slate-300">
+                        <span className="text-sm flex items-center">
+                          <Tag className="h-3 w-3 mr-1" /> {item.category}
                         </span>
-                        <span className="text-sm text-muted-foreground flex items-center">
-                          <Calendar className="h-3 w-3 mr-1" />
-                          {formatDate(item.publishedAt)}
+                        <span className="text-sm flex items-center">
+                          <Calendar className="h-3 w-3 mr-1" /> {formatDate(item.publishedAt)}
                         </span>
                       </div>
-                      <CardTitle className="text-xl">{item.title}</CardTitle>
-                    </CardHeader>
-                    <CardContent className="p-0 pb-4 flex-grow">
-                      <p className="text-muted-foreground">{item.summary}</p>
-                    </CardContent>
-                    <CardFooter className="p-0 pt-2 flex justify-between items-center">
-                      <span className="text-sm text-muted-foreground">Автор: {item.author}</span>
-                      <Button asChild variant="ghost" className="gap-1">
-                        <Link href={`/news/${item.id}`}>
-                          Читать полностью <ArrowRight className="h-4 w-4" />
-                        </Link>
-                      </Button>
-                    </CardFooter>
+                      <h2 className="text-xl font-bold drop-shadow">{item.title}</h2>
+                    </div>
+                    <p className="text-slate-200 flex-grow">{item.summary}</p>
+                    <div className="pt-2 flex justify-between items-center text-slate-300">
+                      <span className="text-sm">Автор: {item.author}</span>
+                      <Link href={`/news/${item.id}`} className="underline flex items-center gap-1 hover:text-blue-300">
+                        Читать полностью <ArrowRight className="h-4 w-4" />
+                      </Link>
+                    </div>
                   </div>
                 </div>
-              </Card>
+              </div>
             ))}
           </div>
         </TabsContent>
@@ -100,7 +96,10 @@ export default async function NewsPage() {
           <TabsContent key={category} value={category}>
             <div className="grid grid-cols-1 gap-8">
               {newsByCategory[category].map((item) => (
-                <Card key={item.id} className="overflow-hidden">
+                <div
+                  key={item.id}
+                  className="bg-gradient-to-br from-blue-700 to-purple-700 text-white rounded-xl shadow-xl overflow-hidden hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300"
+                >
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                     <div className="md:col-span-1">
                       <Image
@@ -108,37 +107,31 @@ export default async function NewsPage() {
                         alt={item.title}
                         width={400}
                         height={300}
-                        className="w-full h-full object-cover aspect-video"
+                        className="w-full h-full object-cover rounded-t-xl md:rounded-l-xl md:rounded-r-none"
                       />
                     </div>
                     <div className="md:col-span-2 flex flex-col p-6">
-                      <CardHeader className="p-0 pb-4">
-                        <div className="flex items-center gap-2 mb-2">
-                          <span className="text-sm px-2 py-1 bg-primary/10 text-primary rounded-md flex items-center">
-                            <Tag className="h-3 w-3 mr-1" />
-                            {item.category}
+                      <div className="mb-4">
+                        <div className="flex items-center gap-2 mb-2 text-slate-300">
+                          <span className="text-sm flex items-center">
+                            <Tag className="h-3 w-3 mr-1" /> {item.category}
                           </span>
-                          <span className="text-sm text-muted-foreground flex items-center">
-                            <Calendar className="h-3 w-3 mr-1" />
-                            {formatDate(item.publishedAt)}
+                          <span className="text-sm flex items-center">
+                            <Calendar className="h-3 w-3 mr-1" /> {formatDate(item.publishedAt)}
                           </span>
                         </div>
-                        <CardTitle className="text-xl">{item.title}</CardTitle>
-                      </CardHeader>
-                      <CardContent className="p-0 pb-4 flex-grow">
-                        <p className="text-muted-foreground">{item.summary}</p>
-                      </CardContent>
-                      <CardFooter className="p-0 pt-2 flex justify-between items-center">
-                        <span className="text-sm text-muted-foreground">Автор: {item.author}</span>
-                        <Button asChild variant="ghost" className="gap-1">
-                          <Link href={`/news/${item.id}`}>
-                            Читать полностью <ArrowRight className="h-4 w-4" />
-                          </Link>
-                        </Button>
-                      </CardFooter>
+                        <h2 className="text-xl font-bold drop-shadow">{item.title}</h2>
+                      </div>
+                      <p className="text-slate-200 flex-grow">{item.summary}</p>
+                      <div className="pt-2 flex justify-between items-center text-slate-300">
+                        <span className="text-sm">Автор: {item.author}</span>
+                        <Link href={`/news/${item.id}`} className="underline flex items-center gap-1 hover:text-blue-300">
+                          Читать полностью <ArrowRight className="h-4 w-4" />
+                        </Link>
+                      </div>
                     </div>
                   </div>
-                </Card>
+                </div>
               ))}
             </div>
           </TabsContent>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,12 +55,11 @@ function ChatComponent() {
   }
 
   return (
-    <div className="relative w-96 transition-all duration-300">
+    <div className="w-96 transition-all duration-300">
       <div
-        className="bg-white rounded-lg p-4 shadow-lg border border-gray-200 mb-4 relative"
+        className="bg-slate-800 text-white rounded-xl p-4 shadow-lg mb-4"
         style={{ maxHeight: `${chatHeight}px` }}
       >
-        <div className="absolute bottom-0 right-4 w-4 h-4 bg-white transform rotate-45 translate-y-2"></div>
 
         <div className="flex justify-between items-center mb-4">
           <h3 className="font-bold text-lg flex items-center">
@@ -85,7 +84,7 @@ function ChatComponent() {
             <div
               key={index}
               className={`${
-                msg.isUser ? "bg-blue-600 text-white ml-auto" : "bg-gray-100 text-gray-800 mr-auto"
+                msg.isUser ? "bg-blue-600 text-white ml-auto" : "bg-slate-700 text-white mr-auto"
               } rounded-lg p-3 max-w-[80%] animate-in fade-in slide-in-from-bottom-2`}
             >
               <p className="text-sm">{msg.text}</p>
@@ -106,7 +105,7 @@ function ChatComponent() {
             placeholder="Введите сообщение..."
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
-            className="flex-1 border rounded-l-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="flex-1 bg-slate-900 border border-slate-700 text-white rounded-l-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
           <button
             type="submit"
@@ -130,26 +129,26 @@ export default async function Home() {
   const popularServices = await getPopularServices()
 
   return (
-    <div className="min-h-screen bg-[#e6f0fa]">
+    <div className="min-h-screen">
       <div className="container mx-auto px-4 py-8">
         {/* Hero Section */}
         <section className="py-8">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
             <div>
-              <h1 className="text-4xl md:text-5xl font-bold text-[#2d3748] leading-tight mb-6">
+              <h1 className="text-white text-5xl font-bold drop-shadow-md mb-6">
                 Добро пожаловать
                 <br />
                 на портал услуг штата
                 <br />
                 Davis
               </h1>
-              <p className="text-xl text-gray-600 mb-8">Все нужное теперь на одном портале</p>
+              <p className="text-slate-300 text-lg mb-8">Все нужное теперь на одном портале</p>
             </div>
             <div className="relative flex justify-start">
               <ChatComponent />
 
               <div className="flex justify-start mt-4">
-                <div className="pointer-events-none">
+                <div className="pointer-events-none drop-shadow-2xl">
                   <Image src="/images/robot-assistant.svg" alt="Виртуальный помощник" width={300} height={300} />
                 </div>
               </div>
@@ -158,18 +157,17 @@ export default async function Home() {
         </section>
       </div>
 
-      {/* White background section starting from middle of service icons */}
-      <div className="bg-white pt-20 pb-12 -mt-16">
+      <div className="pt-20 pb-12 -mt-16">
         <div className="container mx-auto px-4">
           {/* Service Categories */}
           <section className="grid grid-cols-1 md:grid-cols-3 gap-6 -mt-32">
             <Link
               href="/services"
-              className="block bg-white rounded-lg p-6 text-center shadow-sm hover:shadow-md transition-shadow"
+              className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300 text-center"
             >
-              <div className="w-20 h-20 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <svg
-                  className="text-white h-10 w-10"
+                  className="w-12 h-12 mx-auto"
                   viewBox="0 0 24 24"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -183,16 +181,16 @@ export default async function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="text-xl font-medium text-[#2d3748]">Услуги</h3>
+              <h3 className="text-xl font-bold drop-shadow">Услуги</h3>
             </Link>
 
             <Link
               href="/jobs"
-              className="block bg-white rounded-lg p-6 text-center shadow-sm hover:shadow-md transition-shadow"
+              className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300 text-center"
             >
-              <div className="w-20 h-20 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <svg
-                  className="text-white h-10 w-10"
+                  className="w-12 h-12 mx-auto"
                   viewBox="0 0 24 24"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -213,16 +211,16 @@ export default async function Home() {
                   />
                 </svg>
               </div>
-              <h3 className="text-xl font-medium text-[#2d3748]">Вакансии</h3>
+              <h3 className="text-xl font-bold drop-shadow">Вакансии</h3>
             </Link>
 
             <Link
               href="/faq"
-              className="block bg-white rounded-lg p-6 text-center shadow-sm hover:shadow-md transition-shadow"
+              className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300 text-center"
             >
-              <div className="w-20 h-20 bg-blue-600 rounded-lg flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <svg
-                  className="text-white h-10 w-10"
+                  className="w-12 h-12 mx-auto"
                   viewBox="0 0 24 24"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
@@ -244,15 +242,15 @@ export default async function Home() {
                 </svg>
               </div>
               <div className="text-center">
-                <p className="text-lg text-[#2d3748]">Часто задаваемые</p>
-                <p className="text-lg text-[#2d3748]">вопросы!</p>
+                <p className="text-lg">Часто задаваемые</p>
+                <p className="text-lg">вопросы!</p>
               </div>
             </Link>
           </section>
 
           {/* Popular Services */}
           <section className="py-12">
-            <h2 className="text-2xl font-bold text-[#2d3748] mb-6">Популярные услуги</h2>
+            <h2 className="text-2xl font-bold text-white mb-6 drop-shadow">Популярные услуги</h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-4xl mx-auto">
               {popularServices.slice(0, 4).map((service) => (
                 <ServiceCard key={service.id} service={service} />

--- a/app/services/[id]/page.tsx
+++ b/app/services/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { Clock, FileText, Building, DollarSign, FileCheck, ArrowLeft } from "lucide-react"
@@ -33,105 +33,100 @@ export default async function ServicePage({ params }: { params: { id: string } }
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <Link href="/services" className="flex items-center text-muted-foreground hover:text-foreground mb-6">
+      <Link href="/services" className="flex items-center text-slate-300 hover:text-white mb-6">
         <ArrowLeft className="mr-2 h-4 w-4" />
         Назад к списку услуг
       </Link>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <div className="lg:col-span-2">
-          <Card>
-            <CardHeader>
-              <div className="flex items-start gap-4">
-                <div className="p-2 bg-primary/10 rounded-md">
-                  <FileText className="h-6 w-6 text-primary" />
-                </div>
-                <div>
-                  <CardTitle className="text-2xl">{service.title}</CardTitle>
-                  <CardDescription className="mt-2">{service.description}</CardDescription>
-                </div>
+          <div className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl">
+            <div className="flex items-start gap-4 mb-6">
+              <FileText className="w-12 h-12" />
+              <div>
+                <h2 className="text-2xl font-bold drop-shadow mb-2">{service.title}</h2>
+                <p className="text-slate-200">{service.description}</p>
               </div>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-6">
-                <div>
-                  <h3 className="font-medium mb-2">Требования</h3>
-                  <p className="text-muted-foreground">{service.requirements}</p>
-                </div>
+            </div>
+            <div className="space-y-6">
+              <div>
+                <h3 className="font-medium mb-2">Требования</h3>
+                <p className="text-slate-300">{service.requirements}</p>
+              </div>
 
-                <Separator />
+              <Separator />
 
-                <div>
-                  <h3 className="font-medium mb-2">Процедура получения</h3>
-                  <p className="text-muted-foreground">{service.procedure}</p>
-                </div>
+              <div>
+                <h3 className="font-medium mb-2">Процедура получения</h3>
+                <p className="text-slate-300">{service.procedure}</p>
+              </div>
 
-                <Separator />
+              <Separator />
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                   <div className="flex items-start gap-2">
-                    <Clock className="h-5 w-5 text-muted-foreground mt-0.5" />
+                    <Clock className="h-5 w-5 text-slate-300 mt-0.5" />
                     <div>
                       <h4 className="font-medium">Срок оказания</h4>
-                      <p className="text-muted-foreground">{service.duration}</p>
+                        <p className="text-slate-300">{service.duration}</p>
                     </div>
                   </div>
 
                   <div className="flex items-start gap-2">
-                    <DollarSign className="h-5 w-5 text-muted-foreground mt-0.5" />
+                    <DollarSign className="h-5 w-5 text-slate-300 mt-0.5" />
                     <div>
                       <h4 className="font-medium">Стоимость</h4>
-                      <p className="text-muted-foreground">{service.cost} $</p>
+                        <p className="text-slate-300">{service.cost} $</p>
                     </div>
                   </div>
 
                   <div className="flex items-start gap-2">
-                    <Building className="h-5 w-5 text-muted-foreground mt-0.5" />
+                    <Building className="h-5 w-5 text-slate-300 mt-0.5" />
                     <div>
                       <h4 className="font-medium">Ответственный орган</h4>
-                      <p className="text-muted-foreground">{service.department}</p>
+                        <p className="text-slate-300">{service.department}</p>
                     </div>
                   </div>
                 </div>
               </div>
-            </CardContent>
-          </Card>
+            </div>
+          </div>
         </div>
 
-        <div>
-          <Card>
-            <CardHeader>
-              <CardTitle>Получить услугу</CardTitle>
-              <CardDescription>Выберите удобный способ получения услуги</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <Button asChild className="w-full">
-                <Link href={service.applyUrl ?? "#"} target="_blank" rel="noopener noreferrer">
-                  Подать заявление онлайн
-                </Link>
-              </Button>
-              <Button asChild variant="outline" className="w-full">
-                <Link href={settings?.question_link ?? "#"} target="_blank" rel="noopener noreferrer">
-                  Задать вопрос
-                </Link>
-              </Button>
+          <div>
+            <div className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl">
+              <div className="mb-4">
+                <h3 className="text-xl font-bold drop-shadow">Получить услугу</h3>
+                <p className="text-slate-300">Выберите удобный способ получения услуги</p>
+              </div>
+              <div className="space-y-4">
+                <Button asChild className="w-full">
+                  <Link href={service.applyUrl ?? "#"} target="_blank" rel="noopener noreferrer">
+                    Подать заявление онлайн
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" className="w-full">
+                  <Link href={settings?.question_link ?? "#"} target="_blank" rel="noopener noreferrer">
+                    Задать вопрос
+                  </Link>
+                </Button>
 
-              {service.centers.length > 0 && (
-                <div className="pt-4">
-                  <h4 className="font-medium mb-2">Центры оказания услуги</h4>
-                  <ul className="space-y-2 text-sm">
-                    {service.centers.map((center, idx) => (
-                      <li key={idx} className="flex items-start gap-2">
-                        <FileCheck className="h-4 w-4 text-muted-foreground mt-0.5" />
-                        <span>{center}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+                {service.centers.length > 0 && (
+                  <div className="pt-4">
+                    <h4 className="font-medium mb-2">Центры оказания услуги</h4>
+                    <ul className="space-y-2 text-sm">
+                      {service.centers.map((center, idx) => (
+                        <li key={idx} className="flex items-start gap-2">
+                        <FileCheck className="h-4 w-4 text-slate-300 mt-0.5" />
+                          <span>{center}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
       </div>
     </div>
   )

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -31,8 +31,8 @@ export default async function ServicesPage() {
     <div className="container mx-auto px-4 py-8">
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
         <div>
-          <h1 className="text-3xl font-bold mb-2">Государственные услуги</h1>
-          <p className="text-muted-foreground">
+          <h1 className="text-3xl font-bold text-white drop-shadow mb-2">Государственные услуги</h1>
+          <p className="text-slate-300">
             Полный список государственных услуг, предоставляемых порталом E-Davis
           </p>
         </div>
@@ -40,7 +40,7 @@ export default async function ServicesPage() {
       </div>
 
       <Tabs defaultValue="all" className="w-full">
-        <TabsList className="mb-8 flex flex-wrap h-auto">
+        <TabsList className="mb-8 flex flex-wrap h-auto bg-slate-800/50 rounded-lg p-1">
           <TabsTrigger value="all">Все услуги</TabsTrigger>
           {departments.map((department) => (
             <TabsTrigger key={department} value={department}>

--- a/app/treasury/page.tsx
+++ b/app/treasury/page.tsx
@@ -28,10 +28,10 @@ export default async function TreasuryPage() {
 
   return (
     <div className="container mx-auto py-8">
-      <h1 className="text-3xl font-bold mb-6">Состояние и динамика казны</h1>
+      <h1 className="text-3xl font-bold text-white drop-shadow mb-6">Состояние и динамика казны</h1>
 
       <div className="grid gap-6 md:grid-cols-2 mb-6">
-        <Card>
+        <Card className="bg-gradient-to-br from-blue-700 to-purple-700 text-white shadow-xl">
           <CardHeader>
             <CardTitle>Текущее состояние казны</CardTitle>
             <CardDescription>
@@ -50,12 +50,12 @@ export default async function TreasuryPage() {
               </div>
             )}
             {currentTreasury?.comment && (
-              <div className="mt-4 text-sm text-muted-foreground">{currentTreasury.comment}</div>
+              <div className="mt-4 text-sm text-slate-300">{currentTreasury.comment}</div>
             )}
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="bg-gradient-to-br from-blue-700 to-purple-700 text-white shadow-xl">
           <CardHeader>
             <CardTitle>Статистика</CardTitle>
             <CardDescription>Основные показатели</CardDescription>
@@ -63,23 +63,23 @@ export default async function TreasuryPage() {
           <CardContent>
             <dl className="grid grid-cols-2 gap-4">
               <div>
-                <dt className="text-sm font-medium text-muted-foreground">Всего записей</dt>
+                <dt className="text-sm font-medium text-slate-300">Всего записей</dt>
                 <dd className="text-2xl font-bold">{treasuryData.length}</dd>
               </div>
               {treasuryData.length > 0 && (
                 <>
                   <div>
-                    <dt className="text-sm font-medium text-muted-foreground">Первая запись</dt>
+                    <dt className="text-sm font-medium text-slate-300">Первая запись</dt>
                     <dd className="text-2xl font-bold">{new Date(treasuryData[0].date).toLocaleDateString("ru-RU")}</dd>
                   </div>
                   <div>
-                    <dt className="text-sm font-medium text-muted-foreground">Минимальная сумма</dt>
+                    <dt className="text-sm font-medium text-slate-300">Минимальная сумма</dt>
                     <dd className="text-2xl font-bold">
                       {Math.min(...treasuryData.map((entry) => entry.amount)).toLocaleString("ru-RU")} $
                     </dd>
                   </div>
                   <div>
-                    <dt className="text-sm font-medium text-muted-foreground">Максимальная сумма</dt>
+                    <dt className="text-sm font-medium text-slate-300">Максимальная сумма</dt>
                     <dd className="text-2xl font-bold">
                       {Math.max(...treasuryData.map((entry) => entry.amount)).toLocaleString("ru-RU")} $
                     </dd>
@@ -91,7 +91,7 @@ export default async function TreasuryPage() {
         </Card>
       </div>
 
-      <Card className="mb-6">
+      <Card className="mb-6 bg-gradient-to-br from-blue-700 to-purple-700 text-white shadow-xl">
         <CardHeader>
           <CardTitle>Динамика казны</CardTitle>
           <CardDescription>Изменение суммы в казне по дням</CardDescription>
@@ -101,7 +101,7 @@ export default async function TreasuryPage() {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card className="bg-gradient-to-br from-blue-700 to-purple-700 text-white shadow-xl">
         <CardHeader>
           <CardTitle>История изменений</CardTitle>
           <CardDescription>Все записи о состоянии казны</CardDescription>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,83 +3,83 @@ import Image from "next/image"
 
 export function Footer() {
   return (
-    <footer className="py-6 bg-[#e6f0fa] mt-12">
-      <div className="container mx-auto px-4">
+    <footer className="py-6 mt-12">
+      <div className="container mx-auto px-4 text-white">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div>
             <h3 className="font-bold text-lg mb-4">E-Davis</h3>
-            <p className="text-gray-600">Официальный портал услуг штата Davis</p>
+            <p className="text-slate-300">Официальный портал услуг штата Davis</p>
           </div>
           <div>
-            <h4 className="font-medium mb-4 text-gray-600">Услуги</h4>
+            <h4 className="font-medium mb-4 text-slate-300">Услуги</h4>
             <ul className="space-y-2">
               <li>
-                <Link href="/services" className="hover:text-blue-200 text-gray-600">
+                <Link href="/services" className="hover:text-blue-400 text-slate-300">
                   Все услуги
                 </Link>
               </li>
               <li>
-                <Link href="/services/popular" className="hover:text-blue-200 text-gray-600">
+                <Link href="/services/popular" className="hover:text-blue-400 text-slate-300">
                   Популярные услуги
                 </Link>
               </li>
               <li>
-                <Link href="/services/new" className="hover:text-blue-200 text-gray-600">
+                <Link href="/services/new" className="hover:text-blue-400 text-slate-300">
                   Новые услуги
                 </Link>
               </li>
             </ul>
           </div>
           <div>
-            <h4 className="font-medium mb-4 text-gray-600">Информация</h4>
+            <h4 className="font-medium mb-4 text-slate-300">Информация</h4>
             <ul className="space-y-2">
               <li>
-                <Link href="/about" className="hover:text-blue-200 text-gray-600">
+                <Link href="/about" className="hover:text-blue-400 text-slate-300">
                   О правительстве
                 </Link>
               </li>
               <li>
-                <Link href="/news" className="hover:text-blue-200 text-gray-600">
+                <Link href="/news" className="hover:text-blue-400 text-slate-300">
                   Новости
                 </Link>
               </li>
               <li>
-                <Link href="/jobs" className="hover:text-blue-200 text-gray-600">
+                <Link href="/jobs" className="hover:text-blue-400 text-slate-300">
                   Вакансии
                 </Link>
               </li>
               <li>
-                <Link href="/important" className="hover:text-blue-200 text-gray-600">
+                <Link href="/important" className="hover:text-blue-400 text-slate-300">
                   Важная информация
                 </Link>
               </li>
             </ul>
           </div>
           <div>
-            <h4 className="font-medium mb-4 text-gray-600">Поддержка</h4>
+            <h4 className="font-medium mb-4 text-slate-300">Поддержка</h4>
             <ul className="space-y-2">
               <li>
-                <Link href="/faq" className="hover:text-blue-200 text-gray-600">
+                <Link href="/faq" className="hover:text-blue-400 text-slate-300">
                   Часто задаваемые вопросы
                 </Link>
               </li>
               <li>
-                <Link href="/contacts" className="hover:text-blue-200 text-gray-600">
+                <Link href="/contacts" className="hover:text-blue-400 text-slate-300">
                   Контакты
                 </Link>
               </li>
               <li>
-                <Link href="/feedback" className="hover:text-blue-200 text-gray-600">
+                <Link href="/feedback" className="hover:text-blue-400 text-slate-300">
                   Обратная связь
                 </Link>
               </li>
             </ul>
           </div>
         </div>
-        <div className="mt-8 flex justify-center">
+        <div className="mt-8 flex justify-center drop-shadow-2xl">
           <Image src="/images/robot-assistant.svg" alt="E-Davis Robot" width={40} height={40} />
         </div>
-        <div className="mt-8 text-center text-gray-600">
+        <div className="mt-8 text-center text-slate-300">
           <p className="text-sm">© 2025 E-Davis. Все права защищены.</p>
         </div>
       </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,27 +8,24 @@ export function Header() {
   const pathname = usePathname()
 
   return (
-    <header className="py-4 bg-[#e6f0fa]">
+    <header className="py-4">
       <div className="container mx-auto px-4 flex items-center justify-between">
-        <Link href="/" className="text-[#2d3748] text-3xl font-bold">
+        <Link href="/" className="text-white text-3xl font-bold drop-shadow">
           E-Davis
         </Link>
 
-        <nav className="flex items-center space-x-8">
-          <Link href="/services" className="text-[#2d3748]">
+        <nav className="flex items-center space-x-8 text-white">
+          <Link href="/services" className="hover:text-blue-400">
             Услуги
           </Link>
-          <Link href="/news" className="text-[#2d3748]">
+          <Link href="/news" className="hover:text-blue-400">
             Новости
           </Link>
-          <Link href="/news" className="text-[#2d3748]">
-            Новости
-          </Link>
-          <Link href="/jobs" className="text-[#2d3748]">
+          <Link href="/jobs" className="hover:text-blue-400">
             Вакансии
           </Link>
           <div className="relative group">
-            <button className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-full transition-colors flex items-center gap-2">
+            <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-full shadow-md transition flex items-center gap-2">
               О правительстве
               <ChevronDown className="h-4 w-4 transition-transform group-hover:rotate-180" />
             </button>

--- a/components/service-card.tsx
+++ b/components/service-card.tsx
@@ -1,6 +1,4 @@
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { ArrowRight, Clock, FileText } from "lucide-react"
+import { ArrowRight, FileText } from "lucide-react"
 import Link from "next/link"
 import type { Service } from "@/types/service"
 
@@ -10,24 +8,19 @@ interface ServiceCardProps {
 
 export default function ServiceCard({ service }: ServiceCardProps) {
   return (
-    <Card className="h-full flex flex-col">
-      <CardHeader className="flex flex-row items-start gap-4 pb-2">
-        <div className="p-2 bg-primary/10 rounded-md">
-          <FileText className="h-5 w-5 text-primary" />
+    <div className="bg-gradient-to-br from-blue-700 to-purple-700 text-white p-6 rounded-xl shadow-xl hover:scale-105 transition-transform duration-300 hover:ring-2 hover:ring-blue-300 flex flex-col">
+      <div className="flex items-start gap-4 pb-4">
+        <FileText className="w-12 h-12" />
+        <div>
+          <h3 className="text-xl font-bold drop-shadow mb-2">{service.title}</h3>
+          <p className="text-sm text-slate-200 line-clamp-2">{service.description}</p>
         </div>
-        <div className="grid gap-1">
-          <CardTitle className="text-lg">{service.title}</CardTitle>
-          <CardDescription className="line-clamp-2">{service.description}</CardDescription>
-        </div>
-      </CardHeader>
-
-      <CardFooter className="mt-auto pt-2">
-        <Button asChild variant="ghost" className="w-full justify-between">
-          <Link href={`/services/${service.id}`}>
-            Подробнее <ArrowRight className="h-4 w-4" />
-          </Link>
-        </Button>
-      </CardFooter>
-    </Card>
+      </div>
+      <div className="mt-auto pt-4">
+        <Link href={`/services/${service.id}`} className="underline flex items-center gap-1 hover:text-blue-300">
+          Подробнее <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- modernized layout with global dark mode
- restyled news, jobs, services and government pages to use dark cards
- updated government members and capitol plan sections
- refreshed treasury and service details with gradient components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843642d5d488331993ed36e05023e2d