### PR TITLE
Fix param access for Next.js

### DIFF
--- a/app/admin-panel/faq/edit/[id]/page.tsx
+++ b/app/admin-panel/faq/edit/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { use, useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
@@ -14,8 +14,8 @@ import { getSupabaseClient } from "@/lib/supabase/singleton-client"
 import AuthGuard from "@/components/auth-guard"
 
 
-export default function EditFaqPage({ params }: { params: { id: string } }) {
-  const { id } = params
+export default function EditFaqPage({ params }: any) {
+  const { id } = use(params) as { id: string }
   const [question, setQuestion] = useState("")
   const [answer, setAnswer] = useState("")
   const [error, setError] = useState<string | null>(null)

--- a/app/services/[id]/page.tsx
+++ b/app/services/[id]/page.tsx
@@ -8,8 +8,9 @@ import Link from "next/link"
 import { getServiceById } from "@/lib/services"
 import { getPortalSettings } from "@/lib/settings"
 
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
-  const service = await getServiceById(params.id)
+export async function generateMetadata({ params }: any): Promise<Metadata> {
+  const { id } = await params
+  const service = await getServiceById(id)
 
   if (!service) {
     return {
@@ -23,8 +24,9 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
   }
 }
 
-export default async function ServicePage({ params }: { params: { id: string } }) {
-  const service = await getServiceById(params.id)
+export default async function ServicePage({ params }: any) {
+  const { id } = await params
+  const service = await getServiceById(id)
   const settings = await getPortalSettings()
 
   if (!service) {


### PR DESCRIPTION
## Summary
- unwrap async route params using `use`
- fix server component to await params

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68443dd97dc08331af1a11105696c8ce