### PR TITLE
Fix treasury link and government panel paths, add news details

### DIFF
--- a/app/admin-panel/goverment/create/page.tsx
+++ b/app/admin-panel/goverment/create/page.tsx
@@ -64,7 +64,7 @@ export default function CreateGovernmentMemberPage() {
         description: "Член правительства успешно добавлен",
       })
 
-      router.push("/admin-panel/government")
+      router.push("/admin-panel/goverment")
       router.refresh()
     } catch (error: any) {
       console.error("Error creating government member:", error)
@@ -150,7 +150,7 @@ export default function CreateGovernmentMemberPage() {
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={() => router.push("/admin-panel/government")}
+                  onClick={() => router.push("/admin-panel/goverment")}
                   disabled={isSubmitting}
                 >
                   Отмена

--- a/app/admin-panel/goverment/edit/[id]/page.tsx
+++ b/app/admin-panel/goverment/edit/[id]/page.tsx
@@ -110,7 +110,7 @@ export default function EditGovernmentMemberPage({ params }: any) {
         description: "Информация о члене правительства обновлена",
       })
 
-      router.push("/admin-panel/government")
+      router.push("/admin-panel/goverment")
       router.refresh()
     } catch (error: any) {
       const message =
@@ -207,7 +207,7 @@ export default function EditGovernmentMemberPage({ params }: any) {
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={() => router.push("/admin-panel/government")}
+                  onClick={() => router.push("/admin-panel/goverment")}
                   disabled={isSubmitting}
                 >
                   Отмена

--- a/app/admin-panel/goverment/page.tsx
+++ b/app/admin-panel/goverment/page.tsx
@@ -61,7 +61,7 @@ async function GovernmentMembersTable() {
               <TableCell>{member.order_number}</TableCell>
               <TableCell className="text-right">
                 <div className="flex justify-end gap-1">
-                  <Link href={`/admin-panel/government/edit/${member.id}`}>
+                  <Link href={`/admin-panel/goverment/edit/${member.id}`}>
                     <Button variant="ghost" size="icon">
                       <Pencil className="h-4 w-4" />
                       <span className="sr-only">Редактировать</span>
@@ -84,7 +84,7 @@ export default function GovernmentMembersPage() {
       <div className="container mx-auto py-6">
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold">Состав правительства</h1>
-          <Link href="/admin-panel/government/create">
+          <Link href="/admin-panel/goverment/create">
             <Button>
               <PlusCircle className="h-4 w-4 mr-2" />
               Добавить

--- a/app/news/[id]/loading.tsx
+++ b/app/news/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return null
+}

--- a/app/news/[id]/page.tsx
+++ b/app/news/[id]/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next"
+import { notFound } from "next/navigation"
+import { getNewsById } from "@/lib/news"
+import { formatDate } from "@/lib/utils"
+import Link from "next/link"
+import Image from "next/image"
+import { ArrowLeft, Calendar } from "lucide-react"
+
+export async function generateMetadata({ params }: any): Promise<Metadata> {
+  const news = await getNewsById(params.id)
+  if (!news) {
+    return { title: "Новость не найдена - E-Davis" }
+  }
+  return {
+    title: `${news.title} - E-Davis`,
+    description: news.summary,
+  }
+}
+
+export default async function NewsItemPage({ params }: any) {
+  const news = await getNewsById(params.id)
+  if (!news) {
+    notFound()
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Link href="/news" className="flex items-center text-slate-300 hover:text-white mb-6">
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Назад к новостям
+      </Link>
+      <div className="bg-gradient-to-br from-blue-700 to-purple-700 text-white rounded-xl shadow-xl overflow-hidden">
+        {news.imageUrl && (
+          <Image src={news.imageUrl} alt={news.title} width={800} height={400} className="w-full h-64 object-cover" />
+        )}
+        <div className="p-6 space-y-4">
+          <h1 className="text-2xl font-bold drop-shadow">{news.title}</h1>
+          <div className="flex items-center gap-2 text-slate-300 text-sm">
+            <Calendar className="h-4 w-4" />
+            <span>{formatDate(news.publishedAt)}</span>
+            <span className="ml-auto">{news.author}</span>
+          </div>
+          <p className="whitespace-pre-line text-slate-200">{news.content}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -48,7 +48,7 @@ export function Header() {
                 >
                   Состав Правительства
                 </Link>
-                <Link href="treasury" className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                <Link href="/treasury" className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                   Состояние и динамика казны
                 </Link>
               </div>


### PR DESCRIPTION
## Summary
- fix header link to treasury
- fix government admin panel routes
- implement news article page

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844834039148331b712a8514ccbc2d6