### PR TITLE
Add contacts page and favicon

### DIFF
--- a/app/contacts/page.tsx
+++ b/app/contacts/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+export const metadata: Metadata = {
+  title: "Контакты - E-Davis",
+  description: "Контактная информация портала E-Davis",
+}
+
+export default function ContactsPage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold text-white drop-shadow mb-6">Контакты</h1>
+      <div className="bg-slate-800/50 rounded-xl shadow-xl p-6 space-y-4">
+        <p className="text-slate-300">
+          По IC вопросам (услуги, новости и тд.) обращайтесь в DS -{' '}
+          <Link
+            href="https://www.discordapp.com/users/852843568259530772"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-400 hover:underline"
+          >
+            renecounty
+          </Link>
+        </p>
+        <p className="text-slate-300">
+          По тех. вопросам сайтов и ботв, а также по поводу заказов обращайтесь в DS -{' '}
+          <Link
+            href="https://www.discordapp.com/users/213012661959393280"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-400 hover:underline"
+          >
+            qitoly
+          </Link>{' '}
+          или в telegram -{' '}
+          <a
+            href="https://t.me/QitolyAsk"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-400 hover:underline"
+          >
+            t.me/QitolyAsk
+          </a>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,10 @@ import { Footer } from "@/components/footer"
 export const metadata = {
   title: "E-Davis",
   description: "Портал услуг штата Davis",
-    generator: 'v0.dev'
+  generator: "v0.dev",
+  icons: {
+    icon: "/favicon.svg",
+  },
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -19,6 +22,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           href="https://fonts.googleapis.com/css2?family=PT+Sans+Caption:wght@400;700&display=swap"
           rel="stylesheet"
         />
+        <link rel="icon" href="/favicon.svg" />
       </head>
       <body className="bg-gradient-to-br from-slate-900 to-purple-900 text-white min-h-screen">
         <Header />


### PR DESCRIPTION
## Summary
- add a basic `contacts` page with contact links
- include favicon in app metadata and layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684489e3a12883319d6e7e23fcea03ee