### PR TITLE
Enhance chat suggestions

### DIFF
--- a/lib/search.ts
+++ b/lib/search.ts
@@ -3,11 +3,17 @@ import { getAllFaqs } from "@/lib/faq"
 import { getAllNews } from "@/lib/news"
 import { getAllJobs } from "@/lib/jobs"
 
+export interface SearchResult {
+  id: string
+  title: string
+  link: string
+}
+
 /**
  * Search across services, news, jobs and FAQs.
- * Returns an array of strings describing found items.
+ * Returns an array of search results with links.
  */
-export async function searchSite(query: string): Promise<string[]> {
+export async function searchSite(query: string): Promise<SearchResult[]> {
   const q = query.toLowerCase()
   try {
     const [services, news, jobs, faqs] = await Promise.all([
@@ -17,29 +23,45 @@ export async function searchSite(query: string): Promise<string[]> {
       getAllFaqs(),
     ])
 
-    const results: string[] = []
+    const results: SearchResult[] = []
 
     services.forEach((s) => {
       if (s.title.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)) {
-        results.push(`Услуга: ${s.title}`)
+        results.push({
+          id: s.id,
+          title: `Услуга: ${s.title}`,
+          link: `/services/${s.id}`,
+        })
       }
     })
 
     news.forEach((n) => {
       if (n.title.toLowerCase().includes(q) || n.summary.toLowerCase().includes(q)) {
-        results.push(`Новость: ${n.title}`)
+        results.push({
+          id: n.id,
+          title: `Новость: ${n.title}`,
+          link: "/news",
+        })
       }
     })
 
     jobs.forEach((j) => {
       if (j.title.toLowerCase().includes(q) || j.description.toLowerCase().includes(q)) {
-        results.push(`Вакансия: ${j.title}`)
+        results.push({
+          id: j.id,
+          title: `Вакансия: ${j.title}`,
+          link: "/jobs",
+        })
       }
     })
 
     faqs.forEach((f) => {
       if (f.question.toLowerCase().includes(q) || f.answer.toLowerCase().includes(q)) {
-        results.push(`FAQ: ${f.question}`)
+        results.push({
+          id: f.id,
+          title: `FAQ: ${f.question}`,
+          link: "/faq",
+        })
       }
     })
 


### PR DESCRIPTION
## Summary
- rework `searchSite` to return linked results
- add dynamic expansion and internal scrolling for chat
- render search suggestions as buttons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68449d9e4a4483319d773be916b1526f